### PR TITLE
Update tape and test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "'Dominic Tarr' <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "license": "MIT",
   "devDependencies": {
-    "tape": "~0.2.2",
+    "tape": "~2.13.3",
     "observable": "~2.1.2",
     "ispy": "~0.1.2",
     "simulate": "0.0.3"
@@ -23,7 +23,7 @@
     "html-element": false
   },
   "scripts": {
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "test": "tape test/*.js"
   },
   "testling": {
     "files": "test/*.js",


### PR DESCRIPTION
In node and chrome I get a lot of duplicate tests when running old 0.2.x versions of tape. With this update I still get 11 tests failing in node but all pass in chrome.

As for the test script, I prefer the tap output from the tape command.
