### PR TITLE
docs(readme): add hyperaxe to ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,10 @@ h.cleanup()
 * [dom2hscript](https://github.com/AkeemMcLennon/dom2hscript) - Frontend library for parsing HTML into hyperscript using the browser's built in parser.
 * [html2hscript.herokuapp.com](http://html2hscript.herokuapp.com/) - Online Tool that converts html snippets to hyperscript
 * [html2hyperscript](https://github.com/unframework/html2hyperscript) - Original commandline utility to convert legacy HTML markup into hyperscript
-* [hyperscript-helpers](https://github.com/ohanhi/hyperscript-helpers) - write `div(h1('hello')` instead of `h('div', h('h1', 'hello'))`
-* [react-hyperscript](https://github.com/mlmorg/react-hyperscript)  - use hyperscript with React.
+* [hyperscript-helpers](https://github.com/ohanhi/hyperscript-helpers) - write `div(h1('hello'))` instead of `h('div', h('h1', 'hello'))`
+* [react-hyperscript](https://github.com/mlmorg/react-hyperscript) - use hyperscript with React.
+* [hyperaxe](https://github.com/ungoldman/hyperaxe) - an enchanted hyperscript weapon.
 
 ## License
 
 MIT
-
-
-


### PR DESCRIPTION
Adding [hyperaxe](https://github.com/ungoldman/hyperaxe) to the ecosystem section at @mixmix's [suggestion](https://twitter.com/whimful/status/964990550922248193).