### PR TITLE
Use nyc for test code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 node_modules
 node_modules/*
 npm_debug.log
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# nyc test coverage
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
   "author": "'Dominic Tarr' <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "license": "MIT",
   "devDependencies": {
-    "tape": "~2.13.3",
-    "observable": "~2.1.2",
     "ispy": "~0.1.2",
-    "simulate": "0.0.3"
+    "nyc": "^13.1.0",
+    "observable": "~2.1.2",
+    "simulate": "0.0.3",
+    "tape": "~2.13.3"
   },
   "dependencies": {
     "browser-split": "0.0.0",
@@ -23,7 +24,7 @@
     "html-element": false
   },
   "scripts": {
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "test": "nyc --reporter=lcov tape test/**/*.js"
   },
   "testling": {
     "files": "test/*.js",


### PR DESCRIPTION
After running `npm test`, a code coverage report can be found at
`./coverage/lcov-report/index.html`. Having a code coverage report will
help to ensure that unit tests are effective.

Signed-off-by: Lucian <lucian.buzzo@gmail.com>