### PR TITLE
Add .editorconfig file to project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Adding a .editorconfig file will make it easier to maintain consistent
code styles between different contributors. Its a commonly used standard
and is well supported in many IDEs.

From https://editorconfig.org/ :

> EditorConfig helps developers define and maintain consistent coding styles
> between different editors and IDEs. The EditorConfig project consists of a
> file format for defining coding styles and a collection of text editor
> plugins that enable editors to read the file format and adhere to defined
> styles.

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>