### PR TITLE
Fix indentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,13 +321,13 @@ h(&#39;div#page&#39;,
       h(&#39;li&#39;, &#39;one&#39;),
       h(&#39;li&#39;, &#39;two&#39;),
       h(&#39;li&#39;, &#39;three&#39;))),
-    h(&#39;h2&#39;, &#39;content title&#39;,  { style: {&#39;background-color&#39;: &#39;#f22&#39;} }),
-    h(&#39;p&#39;, 
-      &quot;so it&#39;s just like a templating engine,\n&quot;,
-      &quot;but easy to use inline with javascript\n&quot;),
-    h(&#39;p&#39;, 
-      &quot;the intention is for this to be used to create\n&quot;,
-      &quot;reusable, interactive html widgets. &quot;))</code></pre>
+  h(&#39;h2&#39;, &#39;content title&#39;,  { style: {&#39;background-color&#39;: &#39;#f22&#39;} }),
+  h(&#39;p&#39;, 
+    &quot;so it&#39;s just like a templating engine,\n&quot;,
+    &quot;but easy to use inline with javascript\n&quot;),
+  h(&#39;p&#39;, 
+    &quot;the intention is for this to be used to create\n&quot;,
+    &quot;reusable, interactive html widgets. &quot;))</code></pre>
 <h2>h (tag, attrs, [text?, Elements?,...])</h2>
 <p>Create an <code>HTMLElement</code>. first argument must be the tag name.</p>
 <h3>classes &amp; id</h3>


### PR DESCRIPTION
Based on the number of end-parens `)` on line 323, the rest of the example was indented too far.