### PR TITLE
Add better support for aria-* attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function context () {
               e.setAttribute(v, l[k][v])
             }
           }
-          else if (k.substr(0, 5) === "data-") {
+          else if (/^(data|aria)-/.test(k)) {
             e.setAttribute(k, l[k])
           } else {
             e[k] = l[k]

--- a/test/index.js
+++ b/test/index.js
@@ -82,6 +82,12 @@ test('sets data attributes', function(t){
   t.end()
 })
 
+test('sets aria attributes', function(t){
+  var div = h('div', {'aria-label': 'Close'})
+  t.equal(div.getAttribute('aria-label'), 'Close')
+  t.end()
+})
+
 test('boolean, number, date, regex get to-string\'ed', function(t){
   var e = h('p', true, false, 4, new Date('Mon Jan 15 2001'), /hello/)
   t.assert(e.outerHTML.match(/<p>truefalse4Mon Jan 15.+2001.*\/hello\/<\/p>/))


### PR DESCRIPTION
Improves support for `aria-*` attributes without having to nest in `attrs`.
Implementation is the same as `data-*` attributes.