### PR TITLE
Merge classes from tag and attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,8 @@ function context () {
           }
           else if (k.substr(0, 5) === "data-") {
             e.setAttribute(k, l[k])
+          } else if (k === 'class') {
+            l[k].split(/\s+/).forEach(klass => ClassList(e).add(klass))
           } else {
             e[k] = l[k]
           }

--- a/test/index.js
+++ b/test/index.js
@@ -159,3 +159,10 @@ test('unicode selectors', function (t) {
   t.equal(h('span#⛄').outerHTML, '<span id="⛄"></span>')
   t.end()
 })
+
+test('classes from tag and attrs are merged', t => {
+  t.equal(h('.c1', {class: 'c2'}).outerHTML, '<div class="c1 c2"></div>')
+  t.equal(h('.c1.c2', {class: 'c3 c4'}).outerHTML, '<div class="c1 c2 c3 c4"></div>')
+  t.equal(h('.c1.c2', {class: 'c2 c3'}).outerHTML, '<div class="c1 c2 c3"></div>')
+  t.end()
+})


### PR DESCRIPTION
Before this commit, the following code:

    const h = require('hyperscript')
    h('.c1.c2', {class: 'c2 c3'}, 'Hello').outerHTML

...yields:

    '<div class="c1 c2" class="c2 c3">Hello</div>'

This is actually incorrect HTML according to the [W3C Markup Validator](https://validator.w3.org/#validate_by_input).

The correct output would of course be:

    '<div class="c1 c2 c3">Hello</div>'

This commit achieves the correct output.