### PR TITLE
Treat false attribute values like null/undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ function context () {
         e.appendChild(r = l)
       else if ('object' === typeof l) {
         for (var k in l) {
+          if(l[k] === false) continue
           if('function' === typeof l[k]) {
             if(/^on\w+/.test(k)) {
               (function (k, l) { // capture k, l in the closure

--- a/test/index.js
+++ b/test/index.js
@@ -154,6 +154,12 @@ test('context cleanup removes event handlers', function(t){
   t.end()
 })
 
+test('false-valued attributes are ignored', function (t) {
+  t.equal(h('input', {type: 'text', name: 'foo', required: false}).outerHTML,
+          '<input type="text" name="foo">')
+  t.end()
+})
+
 test('unicode selectors', function (t) {
   t.equal(h('.⛄').outerHTML, '<div class="⛄"></div>')
   t.equal(h('span#⛄').outerHTML, '<span id="⛄"></span>')


### PR DESCRIPTION
Treat false attribute values like null/undefined

I noticed that when an attribute value is `null` or `undefined`, it's omitted entirely:

    const x = require('hyperaxe')
    x.input({name: null, id: undefined, type: 'a'}).outerHTML
    // which yields:
    // => '<input type="a">'

This is convenient (and maybe worth mentioning in the README as a feature) because I can have fewer conditionals in my code.

However, `false` is handled differently:

    x.input({name: false, id: false, type: 'a'}).outerHTML
    // which yields:
    // => '<input name="false" id="false" type="a">'

In particular, this is a (very slight) pain point when handling the `required` attribute of inputs.

    const Input = (type, name, value, required) => {
      return h(`input`, {type, name, value, required: required ? true : null)
    }

Notice the extra noise for the `required` attribute, which is needed so that a value of `false` omits the attribute entirely. (Per the HTML spec, any value for the `required` attribute means that the input is required, so the attribute must be omitted entirely.)

I can't think of a use case where the current behavior is convenient. My idea would technically be a breaking change, but (I think) worth it. Unless I'm missing a good use case for the current behavior.